### PR TITLE
Add PostgreSQL password DB utilities

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -123,6 +123,7 @@ If you have found a bug, please open an issue on Github here: [https://github.co
  * Typo simulation for passwords and seeds
  * Progress bar and ETA display (at the command line)
  * Optional autosave - interrupt and continue password recoveries without losing progress
+ * Manage large password lists with a [Password Database](password_database.md)
  * Automated seed recovery with a simple graphical user interface
  * Ability to search multiple derivation paths simultaneously for a given seed via --pathlist command (example pathlist files in the )
  * “Offline” mode for nearly all supported wallets - use one of the [extract scripts (click for more information)](Extract_Scripts.md) to extract just enough information to attempt password recovery, without giving *btcrecover* or whoever runs it access to *any* of the addresses or private keys in your Bitcoin wallet.

--- a/docs/password_database.md
+++ b/docs/password_database.md
@@ -1,0 +1,37 @@
+# Password Database
+
+These helper scripts make it easy to store large password lists in a PostgreSQL
+database.  They can be useful when distributing password testing across
+multiple machines or when you want to pre-process lists before running
+`btcrecover`.
+
+## Initialising the Database
+
+1. Ensure the Python package `psycopg2` (or `psycopg2-binary`) is installed.
+2. Create a new PostgreSQL database and user if required.
+3. Run the following command to create the required table:
+
+```
+python scripts/create_password_db.py --db-uri postgresql://USER:PASS@HOST/DBNAME
+```
+
+This will create a table named `passwords` with a `pending` status column.
+
+## Loading Passwords
+
+Use `add_passwords.py` to insert passwords from a file or from standard input.
+Duplicate passwords are ignored automatically.
+
+```
+python scripts/add_passwords.py --db-uri postgresql://USER:PASS@HOST/DBNAME passwords.txt
+```
+
+You can also read from standard input and control how many records are inserted
+at once using `--batch-size` (defaults to 1000):
+
+```
+cat biglist.txt | python scripts/add_passwords.py --db-uri postgresql://... --batch-size 5000
+```
+
+All inserted rows will have their `status` set to `pending`.
+

--- a/scripts/add_passwords.py
+++ b/scripts/add_passwords.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+"""Load password lists into PostgreSQL."""
+
+import argparse
+import sys
+import psycopg2
+from psycopg2.extras import execute_values
+
+
+def insert_passwords(conn, passwords, batch_size=1000):
+    with conn.cursor() as cur:
+        for i in range(0, len(passwords), batch_size):
+            batch = [(p,) for p in passwords[i:i+batch_size]]
+            execute_values(
+                cur,
+                "INSERT INTO passwords(password) VALUES %s ON CONFLICT DO NOTHING",
+                batch,
+            )
+    conn.commit()
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Insert passwords into database")
+    parser.add_argument("--db-uri", required=True, help="PostgreSQL connection URI")
+    parser.add_argument("file", nargs="?", help="File with passwords (defaults to stdin)")
+    parser.add_argument("--batch-size", type=int, default=1000, help="Insert batch size")
+    args = parser.parse_args(argv)
+
+    fh = open(args.file, "r", encoding="utf-8") if args.file else sys.stdin
+    conn = psycopg2.connect(args.db_uri)
+
+    passwords = []
+    for line in fh:
+        pw = line.rstrip("\n")
+        if pw:
+            passwords.append(pw)
+            if len(passwords) >= args.batch_size:
+                insert_passwords(conn, passwords, batch_size=args.batch_size)
+                passwords = []
+
+    if passwords:
+        insert_passwords(conn, passwords, batch_size=args.batch_size)
+
+    conn.close()
+    if fh is not sys.stdin:
+        fh.close()
+
+
+if __name__ == "__main__":
+    main()
+
+

--- a/scripts/create_password_db.py
+++ b/scripts/create_password_db.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+"""Create PostgreSQL password database."""
+
+import argparse
+import sys
+import psycopg2
+
+
+def create_table(conn):
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS passwords (
+                id SERIAL PRIMARY KEY,
+                password TEXT UNIQUE,
+                status TEXT NOT NULL DEFAULT 'pending',
+                added_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+    conn.commit()
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Create password database")
+    parser.add_argument(
+        "--db-uri",
+        required=True,
+        help="PostgreSQL connection URI",
+    )
+    args = parser.parse_args(argv)
+
+    conn = psycopg2.connect(args.db_uri)
+    create_table(conn)
+    conn.close()
+
+
+if __name__ == "__main__":
+    main()
+
+


### PR DESCRIPTION
## Summary
- add helper scripts for creating and populating a password database
- document password database usage
- link the docs from the feature list

## Testing
- `python -m py_compile scripts/create_password_db.py scripts/add_passwords.py`
- `python run-all-tests.py --no-pause` *(fails: ModuleNotFoundError: No module named 'Crypto')*