### PR TITLE
Add DB queue expiration cleanup

### DIFF
--- a/btcrecover/btcrpass.py
+++ b/btcrecover/btcrpass.py
@@ -5895,6 +5895,7 @@ def init_parser_common():
         parser_common.add_argument("--disable-save-possible-passwords",       action="store_true", help="Disable saving possible matches to file")
         parser_common.add_argument("--db-uri", metavar="URI", help="PostgreSQL URI for password queue")
         parser_common.add_argument("--db-batch-size", type=int, default=1000, metavar="COUNT", help="batch size when fetching passwords from --db-uri")
+        parser_common.add_argument("--db-expire-hours", type=int, metavar="HOURS", help="reset stale in_progress rows older than HOURS before starting")
         parser_common.add_argument("--version","-v",action="store_true", help="show full version information and exit")
         parser_common.add_argument("--disablesecuritywarnings", "--dsw", action="store_true", help="Disable Security Warning Messages")
         dump_group = parser_common.add_argument_group("Wallet Decryption and Key Dumping")
@@ -7069,6 +7070,8 @@ def parse_arguments(effective_argv, wallet = None, base_iterator = None,
     if args.db_uri:
         global db_queue
         db_queue = DBQueue(args.db_uri, args.db_batch_size)
+        if args.db_expire_hours:
+            db_queue.reset_expired(args.db_expire_hours)
         base_password_generator = db_password_generator
         has_any_wildcards = False
         args.no_eta = True

--- a/docs/db_queue.md
+++ b/docs/db_queue.md
@@ -19,7 +19,20 @@ Example usage:
 ```
 python3 btcrecover.py --wallet wallet.dat \
     --db-uri postgresql://user:pass@localhost/dbname \
-    --db-batch-size 500
+    --db-batch-size 500 \
+    --db-expire-hours 12
 ```
 
 Each fetched password is marked `in_progress`. After testing, entries are updated to `tested`. When a correct password is found the row is marked `found`.
+
+## Requeuing stale rows
+
+Use `--db-expire-hours` to reset any `in_progress` rows whose timestamp is older
+than the specified number of hours. BTCRecover performs this cleanup when it
+starts so that stale entries from crashed workers are retried.
+
+You can also run the cleanup manually from a scheduled task:
+
+```
+python3 -c "from utilities.db_queue import DBQueue; DBQueue('postgresql://user:pass@localhost/dbname').reset_expired(24)"
+```

--- a/docs/password_database.md
+++ b/docs/password_database.md
@@ -36,3 +36,7 @@ cat biglist.txt | python scripts/add_passwords.py --db-uri postgresql://... --ba
 
 All inserted rows will have their `status` set to `pending`.
 
+To automatically retry jobs that were claimed but never completed, use the
+`--db-expire-hours` option when running `btcrecover` or call
+`DBQueue.reset_expired()` from your own scripts.
+


### PR DESCRIPTION
## Summary
- allow resetting stale DB password queue rows
- support `--db-expire-hours` argument for btcrecover
- document queue expiration and cleanup

## Testing
- `python run-all-tests.py` *(fails: ModuleNotFoundError: No module named 'psycopg2')*