### PR TITLE
Add PostgreSQL queue link

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ If you need help, [your best bet is to look at my BTCRecover playlist on YouTube
  * Support for Unicode passwords and seeds
  * Multithreaded searches, with user-selectable thread count
  * Ability to spread search workload over multiple devices
+ * [PostgreSQL password queue](docs/db_queue.md) support (`--db-uri`, `--db-batch-size`)
  * [GPU acceleration](docs/GPU_Acceleration.md) for Bitcoin Core Passwords, Blockchain.com (Main and Second Password), Electrum Passwords + BIP39 and Electrum Seeds
  * Wildcard expansion for passwords
  * Typo simulation for passwords and seeds


### PR DESCRIPTION
## Summary
- mention database queue support in README

## Testing
- `python3 run-all-tests.py` *(fails: ModuleNotFoundError: No module named 'psycopg2')*