### PR TITLE
Add network isolation option

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ If you need help, [your best bet is to look at my BTCRecover playlist on YouTube
  * Multithreaded searches, with user-selectable thread count
  * Ability to spread search workload over multiple devices
  * [PostgreSQL password queue](docs/db_queue.md) support (`--db-uri`, `--db-batch-size`)
+ * Optional `--nointernet` flag to disable all network access except the database
  * [GPU acceleration](docs/GPU_Acceleration.md) for Bitcoin Core Passwords, Blockchain.com (Main and Second Password), Electrum Passwords + BIP39 and Electrum Seeds
  * Wildcard expansion for passwords
  * Typo simulation for passwords and seeds

--- a/btcrecover/btcrpass.py
+++ b/btcrecover/btcrpass.py
@@ -5896,6 +5896,7 @@ def init_parser_common():
         parser_common.add_argument("--db-uri", metavar="URI", help="PostgreSQL URI for password queue")
         parser_common.add_argument("--db-batch-size", type=int, default=1000, metavar="COUNT", help="batch size when fetching passwords from --db-uri")
         parser_common.add_argument("--db-expire-hours", type=int, metavar="HOURS", help="reset stale in_progress rows older than HOURS before starting")
+        parser_common.add_argument("--nointernet", action="store_true", help="block all network access except to the --db-uri host")
         parser_common.add_argument("--version","-v",action="store_true", help="show full version information and exit")
         parser_common.add_argument("--disablesecuritywarnings", "--dsw", action="store_true", help="Disable Security Warning Messages")
         dump_group = parser_common.add_argument_group("Wallet Decryption and Key Dumping")
@@ -6082,6 +6083,12 @@ def parse_arguments(effective_argv, wallet = None, base_iterator = None,
         pass
     #
     args = parser.parse_args(effective_argv)
+
+    if args.nointernet:
+        if not args.db_uri:
+            error_exit("--nointernet requires --db-uri")
+        from utilities.no_internet import restrict_network
+        restrict_network(args.db_uri)
 
     # Do this as early as possible so user doesn't miss any error messages
     if args.pause: enable_pause()

--- a/docs/db_queue.md
+++ b/docs/db_queue.md
@@ -20,8 +20,13 @@ Example usage:
 python3 btcrecover.py --wallet wallet.dat \
     --db-uri postgresql://user:pass@localhost/dbname \
     --db-batch-size 500 \
-    --db-expire-hours 12
+    --db-expire-hours 12 \
+    --nointernet
 ```
+
+The `--nointernet` option blocks all network access except for connections to
+the database specified by `--db-uri`. Use it when the recovery machines should
+remain isolated from the Internet.
 
 Each fetched password is marked `in_progress`. After testing, entries are updated to `tested`. When a correct password is found the row is marked `found`.
 

--- a/utilities/no_internet.py
+++ b/utilities/no_internet.py
@@ -1,0 +1,41 @@
+import socket
+from urllib.parse import urlparse
+
+_patched = False
+
+def restrict_network(db_uri):
+    """Disable outgoing connections except to the host/port in db_uri."""
+    parsed = urlparse(db_uri)
+    allowed_host = parsed.hostname
+    allowed_port = parsed.port or 5432
+
+    global _patched
+    if _patched:
+        return
+    _patched = True
+
+    orig_create_connection = socket.create_connection
+    orig_connect = socket.socket.connect
+    orig_connect_ex = socket.socket.connect_ex
+
+    def guarded_create_connection(address, *args, **kwargs):
+        host, port = address[0], address[1]
+        if host == allowed_host and port == allowed_port:
+            return orig_create_connection(address, *args, **kwargs)
+        raise RuntimeError("Network disabled by --nointernet")
+
+    def guarded_connect(self, address):
+        host, port = address[0], address[1]
+        if host == allowed_host and port == allowed_port:
+            return orig_connect(self, address)
+        raise RuntimeError("Network disabled by --nointernet")
+
+    def guarded_connect_ex(self, address):
+        host, port = address[0], address[1]
+        if host == allowed_host and port == allowed_port:
+            return orig_connect_ex(self, address)
+        raise RuntimeError("Network disabled by --nointernet")
+
+    socket.create_connection = guarded_create_connection
+    socket.socket.connect = guarded_connect
+    socket.socket.connect_ex = guarded_connect_ex


### PR DESCRIPTION
## Summary
- add `--nointernet` CLI flag to block all outbound traffic except to the PostgreSQL queue
- document the new option in README and db_queue docs
- implement helper module `utilities/no_internet.py`

## Testing
- `python run-all-tests.py --no-buffer --no-pause` *(fails: ModuleNotFoundError: No module named 'psycopg2')*