### PR TITLE
Add option to save found password and shutdown

### DIFF
--- a/btcrecover.py
+++ b/btcrecover.py
@@ -58,10 +58,20 @@ if __name__ == "__main__":
 		print()
 		print("You may also consider donating to Gurnec, who created and maintained this tool until late 2017 @ 3Au8ZodNHPei7MQiSVAWb7NB2yqsb48GW4")
 		print()
-		btcrpass.safe_print("Password found: '" + password_found + "'")
-		if any(ord(c) < 32 or ord(c) > 126 for c in password_found):
-			print("HTML Encoded Password:   '" + password_found.encode("ascii", "xmlcharrefreplace").decode() + "'")
-		retval = 0
+                btcrpass.safe_print("Password found: '" + password_found + "'")
+                if any(ord(c) < 32 or ord(c) > 126 for c in password_found):
+                        print("HTML Encoded Password:   '" + password_found.encode("ascii", "xmlcharrefreplace").decode() + "'")
+                if btcrpass.args.found_save_file:
+                        try:
+                                with open(btcrpass.args.found_save_file, "w") as fp:
+                                        fp.write(password_found + "\n")
+                        except Exception as e:
+                                print("Failed to write found password:", e, file=sys.stderr)
+                if btcrpass.args.shutdown_after_found:
+                        import os
+                        cmd = "shutdown -h now" if os.name != "nt" else "shutdown /s /t 0"
+                        os.system(cmd)
+                retval = 0
 
 	elif not_found_msg:
 		print(not_found_msg, file=sys.stderr if btcrpass.args.listpass else sys.stdout)

--- a/btcrecover/btcrpass.py
+++ b/btcrecover/btcrpass.py
@@ -5897,6 +5897,9 @@ def init_parser_common():
         parser_common.add_argument("--db-batch-size", type=int, default=1000, metavar="COUNT", help="batch size when fetching passwords from --db-uri")
         parser_common.add_argument("--db-expire-hours", type=int, metavar="HOURS", help="reset stale in_progress rows older than HOURS before starting")
         parser_common.add_argument("--nointernet", action="store_true", help="block all network access except to the --db-uri host")
+        parser_common.add_argument("--found-save-file", metavar="FILE", help="write found password to FILE")
+        parser_common.add_argument("--shutdown-after-found", action="store_true", help="shutdown the system after saving the password")
+        parser_common.add_argument("--skip-db-found", action="store_true", help="don't mark found password in database")
         parser_common.add_argument("--version","-v",action="store_true", help="show full version information and exit")
         parser_common.add_argument("--disablesecuritywarnings", "--dsw", action="store_true", help="Disable Security Warning Messages")
         dump_group = parser_common.add_argument_group("Wallet Decryption and Key Dumping")
@@ -9332,7 +9335,8 @@ def main():
                 passwords_tried += passwords_tried_last - 1  # just before the found password
                 if args.db_uri:
                     db_queue.mark_tested(batch)
-                    db_queue.mark_found(password_found)
+                    if not args.skip_db_found:
+                        db_queue.mark_found(password_found)
                 if progress:
                     progress.next_update = 0  # force a screen update
                     progress.update(passwords_tried)


### PR DESCRIPTION
## Summary
- add `--found-save-file`, `--shutdown-after-found` and `--skip-db-found` options
- allow writing found password to a file and optionally shutting down
- skip DB `found` update if requested

## Testing
- `python3 run-all-tests.py --no-buffer --no-pause` *(fails: ModuleNotFoundError: No module named 'psycopg2')*

------
https://chatgpt.com/codex/tasks/task_e_68399f7db954832aa26baaaa28b6cf98