### PR TITLE
Improve README and comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,8 +118,10 @@ If you need help, [your best bet is to look at my BTCRecover playlist on YouTube
  * Ability to spread search workload over multiple devices
  * [PostgreSQL password queue](docs/db_queue.md) support (`--db-uri`, `--db-batch-size`)
  * Optional `--nointernet` flag to disable all network access except the database
- * `--found-save-file` to write the found password to a chosen file
- * `--shutdown-after-found` with `--disable-network` to disconnect from the network and shut down automatically
+ * `--found-save-file FILE` to write the found password to FILE
+ * `--shutdown-after-found` to automatically shut down after the password is saved
+ * `--disable-network` to disable all network interfaces before shutdown
+ * `--skip-db-found` to avoid marking the password as found in the database
  * [GPU acceleration](docs/GPU_Acceleration.md) for Bitcoin Core Passwords, Blockchain.com (Main and Second Password), Electrum Passwords + BIP39 and Electrum Seeds
  * Wildcard expansion for passwords
  * Typo simulation for passwords and seeds
@@ -128,6 +130,12 @@ If you need help, [your best bet is to look at my BTCRecover playlist on YouTube
  * Automated seed recovery with a simple graphical user interface
  * Ability to search multiple derivation paths simultaneously for a given seed via --pathlist command (example pathlist files in the )
  * “Offline” mode for nearly all supported wallets - use one of the [extract scripts (click for more information)](docs/Extract_Scripts.md) to extract just enough information to attempt password recovery, without giving *btcrecover* or whoever runs it access to *any* of the addresses or private keys in your Bitcoin wallet.
+
+### Saving and Shutting Down ###
+Use `--found-save-file` to automatically write the recovered password to a file.
+Combine `--shutdown-after-found` with `--disable-network` to power off the
+computer and disconnect from the network after saving. When using the database
+password queue, `--skip-db-found` leaves the queue unchanged.
 
 ## Setup and Usage Tutorials ##
 BTCRecover is a Python (3.8, 3.9, 3.10, 3.11) script so will run on Windows, Linux and Mac environments. [See the installation guide for more info](docs/INSTALL.md)

--- a/btcrecover.py
+++ b/btcrecover.py
@@ -31,7 +31,12 @@ from btcrecover import btcrpass
 import sys, multiprocessing, subprocess, os, re
 
 def disable_network_interfaces():
-        """Attempt to disable all network interfaces."""
+        """Disable all network interfaces on the system.
+
+        Windows systems use the ``netsh`` command while Unix-like
+        platforms rely on ``ip`` or fall back to ``ifconfig``.  Any
+        errors are printed but do not stop execution.  This action
+        usually requires administrative privileges."""
         try:
                 if os.name == "nt":
                         out = subprocess.check_output(["netsh", "interface", "show", "interface"], text=True, encoding="utf-8", errors="ignore")
@@ -93,14 +98,18 @@ if __name__ == "__main__":
                 btcrpass.safe_print("Password found: '" + password_found + "'")
                 if any(ord(c) < 32 or ord(c) > 126 for c in password_found):
                         print("HTML Encoded Password:   '" + password_found.encode("ascii", "xmlcharrefreplace").decode() + "'")
+                # Optionally save the recovered password for later use
                 if btcrpass.args.found_save_file:
                         try:
                                 with open(btcrpass.args.found_save_file, "w") as fp:
                                         fp.write(password_found + "\n")
                         except Exception as e:
                                 print("Failed to write found password:", e, file=sys.stderr)
+
+                # Shut the machine down when requested
                 if btcrpass.args.shutdown_after_found:
 
+                        # Optionally disconnect from the network before shutting down
                         if btcrpass.args.disable_network:
                                 disable_network_interfaces()
 


### PR DESCRIPTION
## Summary
- document found password save & shutdown options
- add details on disabling network before shutdown
- clarify disable_network_interfaces implementation
- comment password save and shutdown logic

## Testing
- `python run-all-tests.py --no-buffer --no-pause` *(fails: ModuleNotFoundError: No module named 'psycopg2')*

------
https://chatgpt.com/codex/tasks/task_e_683aa509a338832a9352e93f323adaf6