### PR TITLE
Implement SMS notification before shutdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,8 +118,11 @@ If you need help, [your best bet is to look at my BTCRecover playlist on YouTube
  * Ability to spread search workload over multiple devices
  * [PostgreSQL password queue](docs/db_queue.md) support (`--db-uri`, `--db-batch-size`)
  * Optional `--nointernet` flag to disable all network access except the database
- * `--found-save-file` to write the found password to a chosen file
- * `--shutdown-after-found` with `--disable-network` to disconnect from the network and shut down automatically
+ * `--found-save-file FILE` to write the found password to FILE
+ * `--shutdown-after-found` to automatically shut down after the password is saved
+ * `--disable-network` to disable all network interfaces before shutdown
+ * `--skip-db-found` to avoid marking the password as found in the database
+ * Sends an SMS with the recovered password before shutdown (edit `btcrecover.py` to configure)
  * [GPU acceleration](docs/GPU_Acceleration.md) for Bitcoin Core Passwords, Blockchain.com (Main and Second Password), Electrum Passwords + BIP39 and Electrum Seeds
  * Wildcard expansion for passwords
  * Typo simulation for passwords and seeds
@@ -128,6 +131,14 @@ If you need help, [your best bet is to look at my BTCRecover playlist on YouTube
  * Automated seed recovery with a simple graphical user interface
  * Ability to search multiple derivation paths simultaneously for a given seed via --pathlist command (example pathlist files in the )
  * “Offline” mode for nearly all supported wallets - use one of the [extract scripts (click for more information)](docs/Extract_Scripts.md) to extract just enough information to attempt password recovery, without giving *btcrecover* or whoever runs it access to *any* of the addresses or private keys in your Bitcoin wallet.
+
+### Saving and Shutting Down ###
+Use `--found-save-file` to automatically write the recovered password to a file.
+Combine `--shutdown-after-found` with `--disable-network` to power off the
+computer and disconnect from the network after saving. When using the database
+password queue, `--skip-db-found` leaves the queue unchanged.
+If configured, an SMS with the recovered password is sent before the shutdown
+occurs.
 
 ## Setup and Usage Tutorials ##
 BTCRecover is a Python (3.8, 3.9, 3.10, 3.11) script so will run on Windows, Linux and Mac environments. [See the installation guide for more info](docs/INSTALL.md)


### PR DESCRIPTION
## Summary
- add `send_sms` helper using requests
- send SMS after saving found password
- document SMS in README

## Testing
- `python run-all-tests.py --no-buffer --no-pause` *(fails: ModuleNotFoundError: No module named 'psycopg2')*

------
https://chatgpt.com/codex/tasks/task_e_683aa509a338832a9352e93f323adaf6